### PR TITLE
WebsocketTransport support and invoke connection error

### DIFF
--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/WebsocketTransport.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/WebsocketTransport.java
@@ -6,14 +6,18 @@ See License.txt in the project root for license information.
 
 package microsoft.aspnet.signalr.client.transport;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 
+import javax.net.ssl.SSLSocketFactory;
+
 import com.google.gson.Gson;
 
 import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.drafts.Draft_17;
 import org.java_websocket.exceptions.InvalidDataException;
 import org.java_websocket.framing.Framedata;
 import org.java_websocket.handshake.ServerHandshake;
@@ -65,7 +69,7 @@ public class WebsocketTransport extends HttpClientTransport {
         final String groupsToken = connection.getGroupsToken() != null ? connection.getGroupsToken() : "";
         final String connectionData = connection.getConnectionData() != null ? connection.getConnectionData() : "";
 
-
+        boolean isSsl = false;
         String url = null;
         try {
             url = connection.getUrl() + "signalr/" + connectionString + '?'
@@ -74,6 +78,15 @@ public class WebsocketTransport extends HttpClientTransport {
                     + "&groupsToken=" + URLEncoder.encode(groupsToken, "UTF-8")
                     + "&messageId=" + URLEncoder.encode(messageId, "UTF-8")
                     + "&transport=" + URLEncoder.encode(transport, "UTF-8");
+            if(connection.getQueryString() != null) {
+            	url += "&" + connection.getQueryString();
+            }
+            if(url.startsWith("https://")){
+            	isSsl = true;
+            	url = url.replace("https://", "wss://");
+            } else if(url.startsWith("http://")){
+            	url = url.replace("http://", "ws://");
+            }
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }
@@ -89,7 +102,7 @@ public class WebsocketTransport extends HttpClientTransport {
             return mConnectionFuture;
         }
 
-        mWebSocketClient = new WebSocketClient(uri) {
+        mWebSocketClient = new WebSocketClient(uri,new Draft_17(), connection.getHeaders(), 0) {
             @Override
             public void onOpen(ServerHandshake serverHandshake) {
                 mConnectionFuture.setResult(null);
@@ -108,6 +121,7 @@ public class WebsocketTransport extends HttpClientTransport {
             @Override
             public void onError(Exception e) {
                 mWebSocketClient.close();
+                mConnectionFuture.triggerError(e);
             }
 
             @Override
@@ -141,6 +155,15 @@ public class WebsocketTransport extends HttpClientTransport {
                 }
             }
         };
+        
+        if(isSsl){
+        	SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+            try {
+            mWebSocketClient.setSocket(factory.createSocket());
+            } catch (IOException e1) {
+                e1.printStackTrace();
+            }
+        }
         mWebSocketClient.connect();
 
         connection.closed(new Runnable() {


### PR DESCRIPTION
1. WebsocketTransport support https;
2. After WebsocketTransport.connect()  onError, invoke mConnectionFuture.triggerError, so that AutomaticTransport will try other transport.
